### PR TITLE
Adding preliminary wf examples

### DIFF
--- a/aiida_yambo/workflows/pwplaceholder.py
+++ b/aiida_yambo/workflows/pwplaceholder.py
@@ -58,7 +58,7 @@ class PwRestartWf(WorkChain):
             while_(cls.pw_should_continue)(
                 cls.pw_continue,
             ),
-            cls.report
+            cls.report_wf
         )
         spec.dynamic_output()
 
@@ -109,7 +109,7 @@ class PwRestartWf(WorkChain):
         self.ctx.success = False
         self.ctx.scf_pk = None 
         self.ctx.nscf_pk = None
-        return ResultToContext(first_pk=Outputs(future)  )
+        return ResultToContext(first_calc=future  )
 
     def pw_should_continue(self):
         if len(self.ctx.pw_pks) ==0: # we never run a single calculation 
@@ -172,9 +172,9 @@ class PwRestartWf(WorkChain):
         future =  submit (PwProcess, **inputs)
         self.ctx.pw_pks.append(future.pid)
         self.ctx.restart += 1
-        return  ResultToContext(last_pk=Outputs(future))
+        return  ResultToContext(last_pk=future)
 
-    def report(self):
+    def report_wf(self):
         """
         Output final quantities
         return information that may be used to figure out

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -7,5 +7,8 @@ yambo:
 scftoyambo:
 	 verdi  run test_scf2yambo.py  --precode np2y_marconi@marconi  --yambocode nyambo_marconi@marconi  --pwcode  qe5.4@marconi  --pseudo CHtest  --structure  569 --parent 898
 
+sconv:
+	verdi  run test_convergence.py   --precode np2y_marconi@marconi  --yambocode nyambo_marconi@marconi  --pwcode  qe5.4@marconi  --pseudo CHtest  --structure  569   --parent  10351  --parent_nscf 10395
+
 convergence:
 	verdi run gwFullConvergence.py --precode p2y_marconi@marconi --yambocode yambo_marconi@marconi --pwcode qe5.4@marconi --pseudo CHtest --structure 569 --parent 963

--- a/examples/test_wf/test_convergence.py
+++ b/examples/test_wf/test_convergence.py
@@ -2,7 +2,7 @@ from aiida.backends.utils import load_dbenv, is_dbenv_loaded
 if not is_dbenv_loaded():
     load_dbenv()
 
-from from aiida_yambo.workflows.yamboconvergence  import  YamboConvergenceWorkflow
+from aiida_yambo.workflows.yamboconvergence  import  YamboConvergenceWorkflow
  
 try:
     from aiida.orm.data.base import Float, Str, NumericType, BaseType, List
@@ -64,7 +64,7 @@ settings_p2y =   ParameterData(dict={"ADDITIONAL_RETRIEVE_LIST":[
                   'r-*','o-*','l-*','l_*','LOG/l-*_CPU_1','aiida/ndb.QP','aiida/ndb.HF_and_locXC'], 'INITIALISE':True})
 
 settings_yambo =  ParameterData(dict={"ADDITIONAL_RETRIEVE_LIST":[
-                  'r-*','o-*','l-*','l_*','LOG/l-*_CPU_1','aiida/ndb.QP','aiida/ndb.HF_and_locXC'] })
+                  'r-*','o-*','l-*','l_*','LOG/l-*_CPU_1','aiida/ndb.QP','aiida/ndb.HF_and_locXC'], 'INITIALISE':False })
 
 
 

--- a/examples/test_wf/test_scf2yambo.py
+++ b/examples/test_wf/test_scf2yambo.py
@@ -140,7 +140,7 @@ settings_p2y =   ParameterData(dict={"ADDITIONAL_RETRIEVE_LIST":[
                   'r-*','o-*','l-*','l_*','LOG/l-*_CPU_1','aiida/ndb.QP','aiida/ndb.HF_and_locXC'], 'INITIALISE':True})
 
 settings_yambo =  ParameterData(dict={"ADDITIONAL_RETRIEVE_LIST":[
-                  'r-*','o-*','l-*','l_*','LOG/l-*_CPU_1','aiida/ndb.QP','aiida/ndb.HF_and_locXC'] })
+                  'r-*','o-*','l-*','l_*','LOG/l-*_CPU_1','aiida/ndb.QP','aiida/ndb.HF_and_locXC'], 'INITIALISE':False })
 
 KpointsData = DataFactory('array.kpoints')
 kpoints = KpointsData()
@@ -192,5 +192,5 @@ if __name__ == "__main__":
           }
     if parent_calc:
           kwargs["parent_folder"] =  parent_calc.out.remote_folder
-    full_result = run(YamboWorkflow, **kwargs )
+    full_result = submit(YamboWorkflow, **kwargs )
     print ("Resutls", full_result)

--- a/examples/test_wf/test_yambo.py
+++ b/examples/test_wf/test_yambo.py
@@ -11,7 +11,7 @@ except ImportError:
     from aiida.workflows2.db_types import Float, Str, NumericType, SimpleData, Bool
     from aiida.workflows2.db_types import  SimpleData as BaseType
     from aiida.orm.data.simple import  SimpleData as SimpleData_
-    from aiida.workflows2.run import run
+    from aiida.workflows2.run import run , submit
 
 from aiida.orm.utils import DataFactory
 ParameterData = DataFactory("parameter")
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         structure = load_node(int(args.structure)) #1791 
     parentcalc = load_node(int(args.parent))
     parent_folder_ = parentcalc.out.remote_folder
-    p2y_result =run(YamboRestartWf, 
+    p2y_result =  submit (YamboRestartWf, 
                     precode= Str( args.precode), 
                     yambocode=Str(args.yambocode),
                     parameters = ParameterData(dict=yambo_parameters) , 


### PR DESCRIPTION
There is now an example for yambo and scf to yambo under the  example/test_wf directoy:
testing yambo:
``` 
verdi run test_yambo.py    --precode np2y_marconi@marconi  --yambocode nyambo_marconi@marconi  --pwcode qe5.4@marconi  --pseudo CHtest  --parent   9275
```

testing SCF to yambo:

```
verdi  run test_scf2yambo.py  --precode np2y_marconi@marconi  --yambocode nyambo_marconi@marconi  --pwcode  qe5.4@marconi  --pseudo CHtest  --structure  569 --parent 898
```