### PR TITLE
Various fix for protocol

### DIFF
--- a/aiida_yambo/workflows/protocols/ypp/ypprestart.yaml
+++ b/aiida_yambo/workflows/protocols/ypp/ypprestart.yaml
@@ -7,9 +7,9 @@ default_inputs:
                     num_machines: 1
                     num_mpiprocs_per_machine: 1
                     num_cores_per_mpiproc: 1
-                max_wallclock_seconds: 30*60  # 30 min
+                max_wallclock_seconds: 1800  # 30 min
                 withmpi: True
-                prepend_text: 'mv ./SAVE/ndb.QP* .',
+                prepend_text: 'mv ./SAVE/ndb.QP* .'
         parameters:
             arguments: ['infver','QPDBs','QPDB_merge']
             variables: {'BoseTemp': [0,'eV'],}
@@ -28,6 +28,6 @@ protocols:
                     num_machines: 1
                     num_mpiprocs_per_machine: 1
                     num_cores_per_mpiproc: 1
-                max_wallclock_seconds: 30*60  # 30 min
+                max_wallclock_seconds: 1800  # 30 min
                 withmpi: True
-                prepend_text: 'cp ndb.QP ./SAVE/.',
+                prepend_text: 'cp ndb.QP ./SAVE/.'

--- a/aiida_yambo/workflows/yamboconvergence.py
+++ b/aiida_yambo/workflows/yamboconvergence.py
@@ -126,7 +126,9 @@ class YamboConvergence(ProtocolMixin, WorkChain):
         if spin_type not in [SpinType.NONE, SpinType.COLLINEAR]:
             raise NotImplementedError(f'spin type `{spin_type}` is not supported.')
 
-        inputs = cls.get_protocol_inputs(protocol, overrides={})
+        if overrides is None:
+            overrides = {}
+        inputs = cls.get_protocol_inputs(protocol, overrides=overrides)
 
         meta_parameters = inputs.pop('meta_parameters',{})
         

--- a/aiida_yambo/workflows/ypprestart.py
+++ b/aiida_yambo/workflows/ypprestart.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import sys
+import warnings
 
 from aiida.orm import RemoteData
-from aiida.orm import Str, Dict, Int
+from aiida.orm import Str, Dict, Int, Bool, load_code
 
 from aiida.common import ValidationError
 
@@ -109,11 +110,11 @@ class YppRestart(ProtocolMixin, BaseRestartWorkChain):
         from aiida_quantumespresso.workflows.protocols.utils import recursive_merge
 
         if isinstance(code, str):           
-            code = orm.load_code(code)
+            code = load_code(code)
 
         inputs = cls.get_protocol_inputs(protocol, overrides={})
 
-        meta_parameters = inputs.pop('meta_parameters')
+        meta_parameters = inputs.pop('meta_parameters', None)
 
 
         # Update the parameters based on the protocol inputs
@@ -143,7 +144,7 @@ class YppRestart(ProtocolMixin, BaseRestartWorkChain):
         builder.clean_workdir = Bool(inputs['clean_workdir'])
 
         if not parent_folder:
-            RaiseError('You must provide a parent folder calculation, either YPP or YAMBO') 
+            warnings.warn('You must provide a parent folder calculation, either YPP or YAMBO') 
         elif isinstance(parent_folder,str):
             pass
         else:


### PR DESCRIPTION
Hi Miki, these are several fixes for `get_builder_from_protocol` to work.

I set the `parent_folder` as warnings since before launching the workchain, the `parent_folder` might be unknown (e.g. it will be created dynamically in a previous step in the meta workchain)