### PR TITLE
Allow restart from several workflow types

### DIFF
--- a/aiida_yambo/calculations/yambo.py
+++ b/aiida_yambo/calculations/yambo.py
@@ -194,7 +194,11 @@ class YamboCalculation(CalcJob):
 
         parent_calc = take_calc_from_remote(parent_calc_folder)
 
-        if parent_calc.process_type=='aiida.calculations:yambo.yambo':
+        if parent_calc.process_type in [
+            'aiida.calculations:yambo.yambo',
+            'aiida.workflows:yambo.yambo.yamborestart',
+            'aiida.workflows:yambo.yambo.yambowf',
+        ]:
             yambo_parent=True
         else:
             yambo_parent=False

--- a/aiida_yambo/calculations/ypp.py
+++ b/aiida_yambo/calculations/ypp.py
@@ -192,11 +192,15 @@ class YppCalculation(CalcJob):
 
         if parent_calc.process_type=='aiida.calculations:yambo.yambo':
             yambo_parent=True
+        elif parent_calc.process_type=='aiida.workflows:yambo.yambo.yamborestart':
+            yambo_parent=True
         elif parent_calc.process_type=='aiida.workflows:yambo.yambo.yambowf':
             yambo_parent=True
         elif parent_calc.process_type=='aiida.workflows:yambo.yambo.yamboconvergence':
             yambo_parent=True
         elif parent_calc.process_type=='aiida.calculations:yambo.ypp':
+            ypp_parent=True
+        elif parent_calc.process_type=='aiida.workflows:yambo.ypp.ypprestart':
             ypp_parent=True
         else:
             raise InputValidationError("YppCalculation parent MUST be a YamboCalculation, not {}".format(parent_calc.process_type))

--- a/aiida_yambo/workflows/protocols/yambo/yamborestart.yaml
+++ b/aiida_yambo/workflows/protocols/yambo/yamborestart.yaml
@@ -8,7 +8,7 @@ default_inputs:
             options:
                 resources:
                     num_machines: 1
-                    num_mpiprocs_per_machine: 16
+                    # num_mpiprocs_per_machine: 16
                     num_cores_per_mpiproc: 1
                 max_wallclock_seconds: 43200  # Twelve hours
                 withmpi: True


### PR DESCRIPTION
Moreover, by removing `num_mpiprocs_per_machine: 16`, the submitted calculation can use the default config in `computer`, usually the max number of CPUs in a node.